### PR TITLE
infinite-scroll on genre with GraphQL pagination

### DIFF
--- a/functions/getGenres.js
+++ b/functions/getGenres.js
@@ -1,21 +1,26 @@
 const fetch = require('node-fetch')
 
 exports.handler = async function (event) {
-  const limit = JSON.parse(event.body)
 
+  const body = JSON.parse(event.body)
   const url = process.env.ASTRA_GRAPHQL_ENDPOINT
   const query = `
     query getAllGenres {
       reference_list (
         value: { label: "genre"},
-        options: { limit: ${JSON.stringify(limit)} }
+        options: {
+          pageSize: ${JSON.stringify(body.pageSize)},
+          pageState: ${JSON.stringify(body.pageState)}
+        }
       ) {
         values {
           value
         }
+        pageState
       }
     }
-  `  
+  `
+
   const response = await fetch(url, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
Different handling of the genre retrieval that implements infinite scroll using pagination.
Keeping states for pageState and "requestedPage", now we ask only for the new genres to add to the locally-retrieved ones (instead of always querying for all genres from the first to the current "limit"). This makes the app ready to scale to a high number of genres avoiding an N**2 network traffic.
Special treatment for first page and code to detect end-of-results are included.